### PR TITLE
docs: add ai-team entrypoint

### DIFF
--- a/docs/ai-team.md
+++ b/docs/ai-team.md
@@ -97,9 +97,9 @@
 - **流程 / 規範 / 模板 / 角色 / ADR 政策類**：`.github/ISSUE_TEMPLATE/ai-process.md`（若不存在 → TODO: 建立或先略過）
 - PR 一律套用 `.github/PULL_REQUEST_TEMPLATE.md`（若不存在 → TODO: 建立或先略過）
 
-（檔案連結，方便檢視）
-- [ai-task.md](../.github/ISSUE_TEMPLATE/ai-task.md)
-- [ai-process.md](../.github/ISSUE_TEMPLATE/ai-process.md)
+（檔案路徑，方便檢視）
+- TODO（尚未建立）：`.github/ISSUE_TEMPLATE/ai-task.md`
+- TODO（尚未建立）：`.github/ISSUE_TEMPLATE/ai-process.md`
 - [PULL_REQUEST_TEMPLATE.md](../.github/PULL_REQUEST_TEMPLATE.md)
 
 ---


### PR DESCRIPTION
Closes #5

## Summary
- 新增 `docs/ai-team.md` 作為 AI 多角色協作的單一入口（repo-native onboarding）。
- Docs-only；不改程式碼、不改架構決策、不新增 automation。

## What changed
- Add `docs/ai-team.md` (v1.0)
- 內容涵蓋：
  - 必讀文件清單（有順序）+ 文件優先序（衝突處理）
  - 標準流程：Issue → PR → Merge → Handoff
  - Handoff SSoT 規則（完整內容放 Issue comment）
  - ADR 指引（何時需要 ADR）
  - 5 分鐘上手占位符 + 系統啟動模板（copy-paste）
- Links：採相對路徑（以 `docs/ai-team.md` 位置為基準），根目錄文件使用 `../requirements.md` / `../architecture.md` / `../tasks.md`

## How to verify
> 請至少列出你實際執行過的指令與人工操作步驟。

人工操作
- [x] 在 GitHub 直接開 `docs/ai-team.md`，確認段落齊全（必讀清單、流程、handoff、ADR、5 分鐘上手、啟動模板、變更紀錄）。
- [x] 點擊所有相對連結，確認可導覽到目標檔案；若目標尚不存在，已在文件內標 TODO（避免 broken link 但仍保留路線圖）。

指令（文件 link-check，擇一）
- [ ] `npx markdown-link-check docs/ai-team.md`（檢查 Markdown 內超連結是否可用；需要 Node/npx）[web:60]

（Docs-only，本 PR 未變更程式碼，因此以下 Gradle 任務若未實際執行，請勿勾選）
- [ ] `./gradlew build`
- [ ] Desktop: `./gradlew run`（若實際 task 不在 root，請改用 `./gradlew :<module>:run`）
- [ ] Wasm: `./gradlew wasmJsBrowserDevelopmentRun`（若實際 task 不在 root，請改用 `./gradlew :<module>:wasmJsBrowserDevelopmentRun`）

## Screenshots / Evidence (optional)
- Desktop:
- Web (GitHub Pages URL):

## Checklist (DoD)
- [ ] 變更範圍合理，與 linked issue 目標一致
- [ ] 主要邏輯放在 `commonMain`；`desktopMain`/`wasmJsMain` 僅薄 entrypoint（N/A：docs-only）
- [ ] 錯誤處理：不會因未捕捉例外導致 UI/程序崩潰（N/A：docs-only）
- [ ] 若有跨平台差異（Desktop vs Wasm），已在 Summary 說明（N/A：docs-only）
- [ ] 已更新文件（README / requirements.md / tasks.md / architecture.md）或註明不需要更新的原因（本 PR 僅新增 docs/ai-team.md）
