### PR TITLE
docs: add version and changelog to communication.md

### DIFF
--- a/docs/communication.md
+++ b/docs/communication.md
@@ -161,18 +161,12 @@ From role → To role: <role:a> → <role:b>
 
 ### Where to look
 - PR: <PR link>
-- Files:
-    - <path>
-    - <path>
+- Files: <path>, <path>
 - ADR(s): docs/decisions/ADR-XXXX-...
 
 ### How to verify
-- Commands:
-    - `./gradlew build` (if applicable)
-    - Desktop: <command> (if applicable)
-    - Wasm: <command> (if applicable)
-- Manual steps:
-    - ...
+- Commands: `./gradlew build` (if applicable); Desktop: <command> (if applicable); Wasm: <command> (if applicable)
+- Manual steps: ...
 
 ### Decisions / Constraints
 - ...
@@ -311,7 +305,7 @@ Owner role: Writer
 Example B — Review Notes（docs PR）
 ```md
 ## Review Summary
-- Scope reviewed: PR #?
+- Scope reviewed: <PR link>
 - Overall status: REQUEST CHANGES
 
 ## Must-fix (Blocking)
@@ -327,10 +321,10 @@ Example C — Handoff（QE → Writer）
 From role → To role: QE → Writer
 
 ### What changed
-- PR #? 已 review，需修正角色名與補 minimal examples
+- <PR link> 已 review，需修正範例一致性（code fence / placeholders）
 
 ### Where to look
-- PR: <link>
+- PR: <PR link>
 - File: docs/communication.md
 
 ### How to verify


### PR DESCRIPTION
## Linked Issue
Closes #7

## Summary
- 完成 `docs/communication.md` v1.0：定義 Work Request / Review Notes / Handoff 的統一格式，讓協作可追溯且不依賴聊天紀錄。
- 統一角色命名為 canonical 短版（Owner/PM/Architect/Coder/QE/DevOps/Writer/Artist），清掉草稿中的非 canonical 角色別名。

## What changed
- Update `docs/communication.md`：
  - 新增/整理 canonical roles 章節（固定拼法）。
  - 定稿三個模板：Work Request / Review Notes（QE）/ Handoff（跨角色交接）。
  - 補齊 `status:*` workflow labels 與 entry/exit 規則。
  - 補齊 cross-cutting labels（decision/handoff/breaking-change/good-first-issue）的貼標準則與 DoD 加碼。
  - 加入 minimal examples（每個 ≤ 15 行，可直接 copy-paste）。
  - 移除草稿中外部 citation 標記（例如 `[web:xxx]`），改為純文字或 repo 內相對路徑。

## How to verify
> 請至少列出你實際執行過的指令與人工操作步驟。

人工操作（已執行）
- [ ] 打開 `docs/communication.md`，確認三個模板與 minimal examples 都存在且可 copy-paste。
- [ ] 全文搜尋確認不再出現非 canonical 角色字樣：Tester / QA / Reviewer / Technical Writer。
- [ ] 以 docs 任務情境（例如 Issue #5 / PR #10 類型）在腦中或本地複製 minimal example，確認欄位不衝突且可填完。

（Docs-only，本 PR 未變更程式碼，因此以下 Gradle 任務若未實際執行，請勿勾選）
- [ ] `./gradlew build`
- [ ] Desktop: `./gradlew run`（若實際 task 不在 root，請改用 `./gradlew :<module>:run`）
- [ ] Wasm: `./gradlew wasmJsBrowserDevelopmentRun`（若實際 task 不在 root，請改用 `./gradlew :<module>:wasmJsBrowserDevelopmentRun`）

## Screenshots / Evidence (optional)
- Desktop:
- Web (GitHub Pages URL):

## Checklist (DoD)
- [ ] 變更範圍合理，與 linked issue 目標一致
- [ ] 主要邏輯放在 `commonMain`；`desktopMain`/`wasmJsMain` 僅薄 entrypoint（N/A：docs-only）
- [ ] 錯誤處理：不會因未捕捉例外導致 UI/程序崩潰（N/A：docs-only）
- [ ] 若有跨平台差異（Desktop vs Wasm），已在 Summary 說明（N/A：docs-only）
- [ ] 已更新文件（README / requirements.md / tasks.md / architecture.md）或註明不需要更新的原因（本 PR 僅更新 docs/communication.md）
