### PR TITLE
[P0] docs: refactor communication.md – remove inline labels, reference github-labels.md

### DIFF
--- a/docs/communication.md
+++ b/docs/communication.md
@@ -1,13 +1,24 @@
 # Communication（溝通與交接格式）
 
-Version: 1.0  
-Last updated: 2026-02-14  
+Version: 1.1  
+Last updated: 2026-02-15  
 Scope: CurrencyViewer（Kotlin Multiplatform / Compose Multiplatform）
 
 本文件定義團隊在 GitHub Issues / Pull Requests / 手動轉述（目前由人類 Owner 在 browser 轉交）時的統一訊息格式。  
 目標：讓任何角色只看「Issue/PR 內容 + 連結的文件」就能開工；交接時不依賴聊天紀錄。
 
 > 規範原則：格式要一致、內容要可驗收、並能追溯到單一真實來源（requirements / architecture / tasks / ADR）。
+
+---
+
+## GitHub Labels（SSOT）
+
+GitHub labels 的名稱、描述、顏色、使用原則，**一律**以 `docs/github-labels.md` 為準（Single Source of Truth）。  
+本文件只描述「何時要貼標、貼標對流程的意義」，不在此重複列出任何 label 定義清單。
+
+若要新增、修改或廢除任何 label：
+- 先更新 `docs/github-labels.md`（SSOT）。
+- 若變更屬於長期政策/流程門檻調整，請依專案規範走 ADR 流程，並在 Issue/PR 連回對應 ADR。
 
 ---
 
@@ -20,9 +31,10 @@ Scope: CurrencyViewer（Kotlin Multiplatform / Compose Multiplatform）
 - `Architect:`
 - `Coder:`
 - `QE:`
-- `DevOps:`
 - `Writer:`
 - `Artist:`
+
+> Issue/PR 的 `role:*` labels 請依 `docs/github-labels.md` 貼標；本文件不重複定義 label 名單。
 
 ---
 
@@ -30,13 +42,13 @@ Scope: CurrencyViewer（Kotlin Multiplatform / Compose Multiplatform）
 
 使用時機：
 - Owner/PM 指派任務給某角色
-- 任何人開新 Issue（尤其是 P0/P1）
-- 任何需要跨角色協作的工作（建議加上 `handoff` label）
+- 任何人開新 Issue（尤其是高優先級事項）
+- 任何需要跨角色協作的工作（若需要跨角色交接，請依 `docs/github-labels.md` 貼上對應標記）
 
 模板：
 ```md
 ## Role / Owner
-Owner role: <Owner / PM / Architect / Coder / QE / DevOps / Writer / Artist>
+Owner role: <Owner / PM / Architect / Coder / QE / Writer / Artist>
 Co-owners (optional): <role:...>
 
 ## Goal (1-2 sentences)
@@ -51,8 +63,8 @@ Co-owners (optional): <role:...>
 - Related Issue/PR:
 
 ## Status (workflow)
-<!-- Optional but recommended -->
-- Current: <status:ready / status:blocked / status:in-progress / status:needs-review / status:needs-decision>
+<!-- Optional but recommended; status:* labels 以 docs/github-labels.md 為準 -->
+- Current: <status:...>
 - Blocker (if blocked): <one clear reason, e.g. "Blocked: waiting for ADR-0001 decision">
 
 ## Scope
@@ -147,13 +159,13 @@ From role → To role:
 
 ## 3) Handoff（跨角色交接）
 使用時機：
-- 一個角色完成工作，交棒給下一角色（例如 QE → Writer、PM → DevOps）
+- 一個角色完成工作，交棒給下一角色（例如 PM → Writer、Coder → QE、QE → Writer）
 - PR 合併後，需要通知下一位接手者「下一步做什麼」
 - 需要由人類 Owner 在 browser 手動轉述時：請用此格式貼在 Issue comment 中（最容易追蹤）
 
 模板：
 ```md
-## Handoff
+### Handoff
 From role → To role: <role:a> → <role:b>
 
 ### What changed
@@ -183,90 +195,31 @@ From role → To role: <role:a> → <role:b>
 ---
 
 ## 4) Issue Status（workflow labels）
-Status labels 用來表示「這張工作目前在哪個流程階段」，讓團隊不用看板也能用 label 篩出：
-- 目前可開工的清單（status:ready）
-- 被阻塞的清單（status:blocked）
-- 正在做的清單（status:in-progress）
-- 等待審查的清單（status:needs-review）
-- 等待決策的清單（status:needs-decision）
+Status labels 用來表示「這張工作目前在哪個流程階段」，讓團隊不用看板也能用 label 篩出清單。
+status:* 的名稱與使用原則請一律依 docs/github-labels.md；本文件不列出/不重複任何 status:* 清單或逐條定義。
 
-原則：
+原則（與 SSOT 一致時，以 SSOT 為準）：
+
 - 一張 open issue 最多只貼 1 個 status（避免衝突）。
-- status 必須對應「下一個 owner / 下一個 action / 明確等待條件」，否則 status 會變成噪音。
 
-狀態定義（含 entry / exit 規則）
+- status 應對應「下一個 action / 明確等待條件」，否則 status 會變成噪音。
 
-```md
-status:ready
-Meaning: 需求/AC/DoD 已清楚、依賴已滿足，可立刻開始。
-Entry: PM/Owner 補齊 Context、AC、Verification，並確認無阻塞。
-Exit: 有人開始執行 → status:in-progress；若發現缺資訊/依賴 → status:blocked 或 status:needs-decision。
-
-status:blocked
-Meaning: 工作無法繼續，且有「單一且具體」的阻塞原因。
-Entry: 執行者遇到依賴/缺資訊，必須在 issue 留下 Blocked: <原因>。
-Exit: 阻塞解除 → status:ready 或 status:in-progress（視是否已有人接手）。
-
-status:in-progress
-Meaning: 有人正在主動處理（通常已有分支/PR 或明確下一步）。
-Entry: 開始動工。
-Exit: 提交 PR 等待審查 → status:needs-review；遇到依賴 → status:blocked。
-
-status:needs-review
-Meaning: 工作已完成到可檢查程度，等待 QE/Owner 驗收或審查。
-Entry: PR ready for review（或明確指定 QE/Owner 驗收）。
-Exit: 需要修改 → status:in-progress；審查通過且已合併/完成 → 關閉 issue（或 status:done 若你們選用）。
-
-status:needs-decision
-Meaning: 卡在方案選擇/政策取捨，需要 Owner/團隊拍板（建議產出 ADR 或在 issue 記錄決議）。
-Entry: 出現不可逆決策點（例如 toolchain/CI policy/資料源取捨）。
-Exit: 決策完成（最好有 ADR 連結）→ status:ready 或 status:in-progress。
-
-status:done
-Meaning: 已完成且不需再行動。
-Note: 通常直接關閉 issue 即可，不一定需要此 label。
-```
+- 若是 blocked，務必在 issue 留下 Blocked: <單一且具體原因>，並在解除後更新 status。
 
 ---
 
 ## 5) Cross-cutting labels（跨領域標記：貼標準則）
-Cross-cutting labels 用來標記「跨模組/跨角色/跨流程」的特殊議題；這些標籤會影響 DoD/交接方式/風險控管。
+Cross-cutting labels 用來標記「跨模組/跨角色/跨流程」的特殊議題，可能影響 DoD、交接方式與風險控管。
 
-原則：
-- 這些標籤可以與 type/area/role/status 並存（它們是不同維度）。
-- 貼上 cross-cutting label 後，Issue/PR 必須滿足對應的額外要求（見下）。
+cross-cutting labels 的名稱與額外要求請一律依 docs/github-labels.md；本文件不重複列出任何 cross-cutting label 定義清單。
 
-decision（會產生或更新ADR ）
+建議做法：
 
-何時貼：
-- 需要在多個方案中選一個，且會影響後續長期維護/相容性/協作方式（例如 toolchain、CI policy、資料源策略、跨平台架構策略）。
-- 同一類決策若不記錄，未來很可能重複討論。
+- 若貼了任何 cross-cutting label，請在 Work Request 的 DoD / Verification / Handoff 補上對應的額外資訊（依 SSOT 規則）。
 
-貼了之後的 DoD 加碼：
-- [ ] 必須新增或更新 ADR：docs/decisions/ADR-XXXX-*.md
-- [ ] Issue/PR 內必須連結該 ADR（Context/Links）
+- 若牽涉長期政策或不可逆決策，優先把決策落在 ADR，再由 Issue/PR 與 Handoff 連回。
 
-handoff（需要跨角色交接）
-何時貼：
-- 這張工作完成後，下一步明確需要由「不同角色」接續（例如 QE → Writer、PM → DevOps）。
-- 工作會拆成多階段、多 PR，需要明確交接點。
 
-貼了之後的 DoD 加碼：
-- [ ] Issue 或 PR 完成時必填 Handoff 區塊（Where to look / How to verify / Risks & follow-ups）
-- [ ] Handoff 內必須指向「下一步的 owner role」與「下一張 issue/PR（若已存在）」
-
-breaking-change（可能破壞相容性）
-何時貼：
-- 變更可能導致升級後無法編譯/無法建置/行為不相容（例如大幅調整 Gradle/toolchain、改 public API、改資料格式或 CLI/任務名稱）。
-貼了之後的 DoD 加碼：
-- [ ] 必須在 Issue/PR 描述「Breaking 的點」與「遷移/回退方式」
-- [ ] 必須補強 Verification（至少 build + 相關平台驗證）
-- [ ] 若是政策性改動，建議同時貼 decision 並補 ADR
-
-good-first-issue（適合新加入者，可選）
-何時貼：
-- 範圍小、風險低、說明清楚、有明確驗收方式，且不需要深度領域知識即可完成。
-- 建議同時確保 issue 具備足夠 Context/Links 與 Verification 指令。
 
 ---
 
@@ -288,28 +241,27 @@ Handoff：記「工作交接」，讓下一角色能直接開始。
 Owner role: Writer
 
 ## Goal (1-2 sentences)
-新增 docs/communication.md v1.0（模板 + minimal examples），可直接 commit。
+更新 docs/communication.md：移除內嵌 labels 定義，改引用 docs/github-labels.md（SSOT）。
 
 ## Context / Links
-- Related Issue: #7
-- roles: docs/roles.md
-- ai-team: docs/ai-team.md
+- Related Issue: #14
+- labels SSOT: docs/github-labels.md
 
 ## Deliverables (DoD)
-- [ ] docs/communication.md v1.0
+- [ ] docs/communication.md 更新
 
 ## Acceptance Criteria (AC)
-- [ ] 三模板齊全且角色名皆 canonical
+- [ ] 文件不再包含任何 labels 清單定義
 ```
 
 Example B — Review Notes（docs PR）
 ```md
-## Review Summary
+### Review Summary
 - Scope reviewed: <PR link>
 - Overall status: REQUEST CHANGES
 
 ## Must-fix (Blocking)
-- [ ] 移除非 canonical 角色名（Reviewer/Technical Writer 等）
+- [ ] 移除非 canonical 角色名（如 Reviewer/Technical Writer 等）
 
 ## Verification
 - [ ] 人工檢查：搜尋關鍵字與連結是否為相對路徑
@@ -337,5 +289,7 @@ From role → To role: QE → Writer
 ---
 
 ## Change log（文件變更紀錄）
+- 2026-02-15 v1.1：移除文件內嵌的 labels 定義清單，改以 docs/github-labels.md 作為 labels SSOT；同步移除 DevOps 角色並對齊最新 canonical roles。
 
-- 2026-02-14 v1.0：初版建立（定稿 Work Request / Review Notes / Handoff 模板，status:* 與 cross-cutting labels 規則，並統一 canonical roles）。
+- 2026-02-14 v1.0：初版建立（定稿 Work Request / Review Notes / Handoff 模板，並統一 canonical roles）。
+


### PR DESCRIPTION
Closes #14

## Links
- Parent: #4
- Related: #12

## What changed
- Updated `docs/communication.md` to remove inline GitHub label definitions (status/cross-cutting lists).
- Added a single SSOT pointer: all label names/rules live in `docs/github-labels.md`.
- Aligned role naming to canonical roles (removed DevOps) and updated handoff wording accordingly.

## How to verify
- [ ] Open `docs/communication.md` and confirm there is no section that enumerates/defines label lists.
- [ ] Search in `docs/communication.md`:
  - [ ] `DevOps` → should return 0 results.
  - [ ] `status:ready` / `status:blocked` / `status:in-progress` / `status:needs-review` / `status:needs-decision` → should return 0 results.
  - [ ] `decision` / `breaking-change` / `good-first-issue` as label-definition sections → should not exist (labels are referenced via SSOT only).
- [ ] Confirm templates still exist and structure is unchanged: Work Request / Review Notes / Handoff / Status / Cross-cutting headings remain.

## Handoff
From role → To role: Writer → PM (optionally QE)

- What changed:
  - Communication doc now references `docs/github-labels.md` for all label definitions; removed inline lists.
- Where to look:
  - File: `docs/communication.md`
  - SSOT: `docs/github-labels.md`
- How to verify:
  - Use the checklist above; optionally run a repo-wide search for `DevOps` and legacy label definitions.
- Risks & follow-ups:
  - If any other docs still embed label lists, open follow-up issues to refactor them to SSOT references.